### PR TITLE
Add Caladan measurement scripts for shmem feature extraction bench

### DIFF
--- a/module/scripts/graph.py
+++ b/module/scripts/graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import re

--- a/module/scripts/graph_measure.sh
+++ b/module/scripts/graph_measure.sh
@@ -1,6 +1,6 @@
 # Goal is to graph keeping data_size at 256
 #./print_measure.sh $1 | tail -n +2 |awk '$2 == 256 {print $3, $4/$1}'
-
+shopt -s expand_aliases
 alias cwk='awk -F, -v OFS=","'
 
 get_data() {
@@ -11,18 +11,21 @@ KMOD_ARRAY=$(get_data kmod-array)
 KMOD_MAP=$(get_data kmod-map)
 EBPF_MAP=$(get_data ebpf-map)
 USER_MMAP=$(get_data user-mmap)
+KSCHED_USER=$(get_data ksched-user)
 
-echo kmod-array ebpf-map kmod-map user-mmap
+echo kmod-array ebpf-map kmod-map user-mmap ksched-user
 for i in 8 16 32 64 128 256 512; do
     printf "$(printf "${KMOD_ARRAY}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $3}')"
     printf "\t$(printf "${EBPF_MAP}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $3}')"
     printf "\t$(printf "${KMOD_MAP}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $3}')"
     printf "\t$(printf "${USER_MMAP}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $3}')"
+    printf "\t$(printf "${KSCHED_USER}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $3}')"
     printf "\t$i"
     printf "\t$(printf "${KMOD_ARRAY}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $4}')"
     printf "\t$(printf "${EBPF_MAP}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $4}')"
     printf "\t$(printf "${KMOD_MAP}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $4}')"
     printf "\t$(printf "${USER_MMAP}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $4}')"
+    printf "\t$(printf "${KSCHED_USER}" | cwk -v DS=$i '$2 == 256 && $1 == DS {print $4}')"
     printf "\n"
 done
 

--- a/module/scripts/take_measure.sh
+++ b/module/scripts/take_measure.sh
@@ -11,8 +11,9 @@ for ds in 8 16 32 64 128 256 512; do
         #make -s undeploy
         #make -s test
         #for i in $(seq 1 30); do python3 python/bench_ebpf_space.py -s ${ms} -d ${ds} 3>>ebpf-map-${ds}-${ms}.stats; done
-        for i in $(seq 1 30); do ./build/test/kdev/bpf_map_bench -n 100000 -s ${ms} -d ${ds} 3>>user-mmap-${ds}-${ms}.stats; done
+        # for i in $(seq 1 30); do ./build/test/kdev/bpf_map_bench -n 100000 -s ${ms} -d ${ds} 3>>user-mmap-${ds}-${ms}.stats; done
         #for i in `seq 1 30`; do ./build/test/e2e/bench_kernel_get/bench_kernel_get -f -n 100000 -s ${ms} -d ${ds} 3>> kmod-map-${ds}-${ms}.stats; done
         #for i in `seq 1 30`; do ./build/test/e2e/bench_kernel_get/bench_kernel_get -a -n 100000 -s ${ms} -d ${ds} 3>> kmod-array-${ds}-${ms}.stats; done
+        for i in `seq 1 30`; do ./test/caladan/ksched_user -n 100000 -s ${ms} -d ${ds} 3>> ksched-user-${ds}-${ms}.stats 4>> returner; done
     done
 done

--- a/module/test/caladan/Dockerfile
+++ b/module/test/caladan/Dockerfile
@@ -1,0 +1,69 @@
+# This Dockerfile acts more as a guide for building and benchmarking the Caladan environment
+# We recommend following these steps in a bare-metal environment
+
+FROM ubuntu:20.04
+
+# Instructions for installing Caladan
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    cmake \
+    pkg-config \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libnuma-dev \
+    uuid-dev \
+    libssl-dev \
+    libaio-dev \
+    libcunit1-dev \
+    libclang-dev \
+    libncurses-dev \
+    meson \
+    python3-pyelftools \
+    libstdc++-10-dev \
+    git \
+    curl \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /caladan
+# Use '.' to clone into current directory
+# Applying the patch sets up ksched for shmem benchmarking
+RUN git clone https://github.com/shenango/caladan.git . && \
+    git reset --hard 14a57f0f405cdbf54f897436002ee472ede2ca40 && \
+    git apply ~/KernMLOps/caladan.patch && \
+    make submodules
+
+# Build Caladan
+ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/lib/gcc/x86_64-linux-gnu/10
+RUN make clean && make && \
+    cd ksched && make clean && make && cd ..
+
+# Setup the module
+RUN ./scripts/setup_machine.sh && lsmod | grep ksched
+
+# Run and measure the Caladan benchmark
+RUN cd ~/KernMLOps/module/test/caladan/ && g++ -Wall -O3 -o ksched_user ksched_user.cpp
+RUN cd ../.. && ./scripts/take_measure.sh
+
+RUN ./scripts/graph_measure.sh | ./scripts/graph.py -t "Performance Comparison" -x "Data Size" -y "Time (ns)" -g 5 -o test.png
+
+######
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env" && \
+    rustup default nightly
+
+# Copy configuration files
+COPY server.config /caladan/
+COPY client.config /caladan/
+COPY ksched_user.c /caladan/
+
+# Build synthetic application
+RUN cd apps/synthetic && \
+    cargo clean && \
+    cargo update && \
+    cargo build --release

--- a/module/test/caladan/caladan.patch
+++ b/module/test/caladan/caladan.patch
@@ -1,0 +1,50 @@
+# This patch makes Caladan's kernel module use a configurable shared memory size
+# Hardcoded to 2048 for now
+# just run 
+# pushd ksched; make clean && make; popd; sudo ./scripts/setup_machine.sh
+# to apply the patch
+
+diff --git a/scripts/setup_machine.sh b/scripts/setup_machine.sh
+index 79cb93c..a591e1e 100755
+--- a/scripts/setup_machine.sh
++++ b/scripts/setup_machine.sh
+@@ -16,7 +16,7 @@ fi
+ # set up the ksched module
+ rmmod ksched
+ rm /dev/ksched
+-insmod $(dirname $0)/../ksched/build/ksched.ko
++insmod $(dirname $0)/../ksched/build/ksched.ko shm_size=1048576
+ mknod /dev/ksched c 280 0
+ chmod uga+rwx /dev/ksched
+
+diff --git a/ksched/ksched.c b/ksched/ksched.c
+index 291d5f7..ec4ed22 100644
+--- a/ksched/ksched.c
++++ b/ksched/ksched.c
+@@ -51,7 +51,10 @@ static struct cdev ksched_cdev;
+
+ /* shared memory between the IOKernel and the Linux Kernel */
+ static __read_mostly struct ksched_shm_cpu *shm;
+-#define SHM_SIZE (NR_CPUS * sizeof(struct ksched_shm_cpu))
++/*#define SHM_SIZE (NR_CPUS * sizeof(struct ksched_shm_cpu))*/
++static unsigned long shm_size = NR_CPUS * sizeof(struct ksched_shm_cpu);
++module_param(shm_size, ulong, 0644);
++MODULE_PARM_DESC(shm_size, "Size of shared memory region in bytes");
+
+ struct ksched_percpu {
+ 	unsigned int		last_gen;
+@@ -524,12 +527,12 @@ static int __init ksched_init(void)
+ 	if (ret)
+ 		goto fail_ksched_cdev_add;
+
+-	shm = vmalloc_user(SHM_SIZE);
++	shm = vmalloc_user(shm_size);
+ 	if (!shm) {
+ 		ret = -ENOMEM;
+ 		goto fail_shm;
+ 	}
+-	memset(shm, 0, SHM_SIZE);
++	memset(shm, 0, shm_size);
+
+ 	ret = ksched_cpuidle_hijack();
+ 	if (ret)

--- a/module/test/caladan/ksched_user.cpp
+++ b/module/test/caladan/ksched_user.cpp
@@ -1,0 +1,128 @@
+#include "../e2e/bench_kernel_get/bench_kernel_get.h"
+#include <cassert>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <linux/bpf.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define ASSERT_ERRNO(x)                                                            \
+  if (!(x)) {                                                                      \
+    int err_errno = errno;                                                         \
+    fprintf(stderr, "%s:%d: errno:%s\n", __FILE__, __LINE__, strerror(err_errno)); \
+    exit(-err_errno);                                                              \
+  }
+
+// constexpr __u64 SAMPLE_VALUE = 0xDEADBEEF;
+constexpr __u64 DEFAULT_NUMBER = 10;
+constexpr __u32 DEFAULT_SIZE = 10;
+constexpr __u32 DEFAULT_DATA_SIZE = 8;
+constexpr int STAT_FD = 3;
+constexpr int RET_FD = 4;
+constexpr __u32 MAX = 16384;
+
+struct data_t {
+  size_t size[MAX / sizeof(__u32)];
+};
+
+data_t temp_buffer;
+
+int main(int argc, char** argv) {
+  __u64 number = DEFAULT_NUMBER;
+  __u32 size = DEFAULT_SIZE;
+  __u32 data_size = 0;
+
+  int c;
+  while ((c = getopt(argc, argv, "n:s:d:")) != -1) {
+    switch (c) {
+      case 'n':
+        number = strtoll(optarg, NULL, 10);
+        break;
+      case 's':
+        size = strtol(optarg, NULL, 10);
+        break;
+      case 'd':
+        data_size = strtol(optarg, NULL, 10);
+        break;
+      default:
+        fprintf(stderr, "%s [-n <number>] [-s <map-size>] [-d <data-size> ]\n", argv[0]);
+        exit(-1);
+        break;
+    }
+  }
+
+  // Resize
+  data_size = data_size < DEFAULT_DATA_SIZE ? DEFAULT_DATA_SIZE : data_size;
+  data_size = data_size / DEFAULT_DATA_SIZE * DEFAULT_DATA_SIZE;
+
+  // Open the device
+  const char* dev_name = "/dev/ksched";
+  int fd = open(dev_name, O_RDWR);
+  if (fd == -1) {
+    perror("Failed to open device");
+    return -1;
+  }
+  
+  // Map the memory region
+  int shm_size = size * data_size;
+  void* ksched_shm = mmap(NULL, shm_size, 
+                          PROT_READ | PROT_WRITE,
+                          MAP_SHARED | MAP_POPULATE | MAP_LOCKED,
+                          fd, 0);
+  if (ksched_shm == MAP_FAILED) {
+    perror("mmap failed");
+    close(fd);
+    return -1;
+  }
+
+  ShiftXor rand{1, 4, 7, 13};
+
+  // Write random data into memory region
+  __u32 key = 0;
+  __u64* sample_buffer = (__u64*)malloc(sizeof(char) * data_size);
+  for (__u64 i = 0; i < size; i++) {
+    key = i;
+    for (size_t j = 0; j < data_size / 8; j++) {
+      sample_buffer[j] = simplerand(&rand);
+    }
+    memcpy((char*)ksched_shm + i * data_size, sample_buffer, data_size);
+  }
+
+
+  rand = {1, 4, 7, 13};
+
+  // Read random data from memory region and time it
+  __u32 returner = 0;
+  const auto start = std::chrono::steady_clock::now();
+  for (__u64 i = 0; i < number; i++) {
+    key = simplerand(&rand) % (shm_size - data_size);
+    memcpy(&temp_buffer, (char*)ksched_shm + key, data_size);
+    for (__u32 j = 0; j < data_size / 4; j++) {
+      returner ^= temp_buffer.size[j];
+    }
+  }
+  const auto stop = std::chrono::steady_clock::now();
+  auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+
+  // Write the file
+  int err = fcntl(STAT_FD, F_GETFD);
+  if (err != -1) {
+    std::cerr << "Output to stats" << std::endl;
+    err = dprintf(STAT_FD, "get_iterations %lld\tmap_size %d\tvalue_size %d\tTime(ns) %ld\n",
+                  number, size, data_size, time);
+    assert(err > 0);
+  }
+
+  err = fcntl(RET_FD, F_GETFD);
+  if (err != -1) {
+    std::cerr << "Output to returner" << std::endl;
+    err = dprintf(RET_FD, "returner %d", returner);
+    assert(err > 0);
+  }
+}


### PR DESCRIPTION
These scripts aim to add support for benchmarking [Caladan](https://github.com/shenango/caladan/)'s shared-memory kernel region with userspace access. See the Dockerfile for setup instructions. Is not currently integrated with the other test scripts build system.