### PR TITLE
feat: collect changes in rss

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -41,3 +41,4 @@ collector_config:
       - block_io
       - perf
       - collapse_huge_pages
+      - mm_rss_stat

--- a/python/kernmlops/data_collection/bpf_instrumentation/__init__.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/__init__.py
@@ -12,6 +12,7 @@ from data_collection.bpf_instrumentation.collapse_huge_page import (
 )
 from data_collection.bpf_instrumentation.file_data_hook import FileDataBPFHook
 from data_collection.bpf_instrumentation.memory_usage_hook import MemoryUsageHook
+from data_collection.bpf_instrumentation.mm_rss_stat import TraceRSSStatBPFHook
 from data_collection.bpf_instrumentation.perf import (
     CustomHWConfigManager,
     PerfBPFHook,
@@ -30,11 +31,11 @@ all_hooks: Final[Mapping[str, type[BPFProgram]]] = {
     PerfBPFHook.name(): PerfBPFHook,
     CollapseHugePageBPFHook.name(): CollapseHugePageBPFHook,
     CBMMBPFHook.name(): CBMMBPFHook,
+    TraceRSSStatBPFHook.name(): TraceRSSStatBPFHook,
 }
 
 def hook_names() -> list[str]:
     return list(all_hooks.keys())
-
 
 __all__ = [
     "all_hooks",

--- a/python/kernmlops/data_collection/bpf_instrumentation/bpf/mm_trace_rss_stat.bpf.c
+++ b/python/kernmlops/data_collection/bpf_instrumentation/bpf/mm_trace_rss_stat.bpf.c
@@ -1,0 +1,38 @@
+#include <linux/minmax.h>
+#include <linux/mm_types.h>
+
+typedef struct rss_stat_output {
+  u32 pid;
+  u32 tgid;
+  u64 ts;
+  s64 file;
+  s64 anon;
+  s64 swap;
+  s64 shmem;
+} rss_stat_output_t;
+
+BPF_PERF_OUTPUT(rss_stat_output);
+
+RAW_TRACEPOINT_PROBE(rss_stat) {
+  struct mm_struct* mm = (struct mm_struct*)ctx->args[0];
+  int member = (int)ctx->args[0];
+  rss_stat_output_t data;
+  memset((void*)&data, 0, sizeof(data));
+  data.pid = mm->owner->pid;
+  data.tgid = mm->owner->tgid;
+  data.ts = bpf_ktime_get_ns();
+  data.file = mm->rss_stat[MM_FILEPAGES].count;
+  data.anon = mm->rss_stat[MM_ANONPAGES].count;
+  data.swap = mm->rss_stat[MM_SWAPENTS].count;
+  data.shmem = mm->rss_stat[MM_SHMEMPAGES].count;
+  if (data.file < 0)
+    data.file = 0;
+  if (data.anon < 0)
+    data.anon = 0;
+  if (data.swap < 0)
+    data.swap = 0;
+  if (data.shmem < 0)
+    data.shmem = 0;
+  rss_stat_output.perf_submit(ctx, &data, sizeof(data));
+  return 0;
+}

--- a/python/kernmlops/data_collection/bpf_instrumentation/mm_rss_stat.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/mm_rss_stat.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+from bcc import BPF
+from data_collection.bpf_instrumentation.bpf_hook import POLL_TIMEOUT_MS, BPFProgram
+from data_schema import CollectionTable
+from data_schema.rss_stat import TraceMMRSSStatDataTable
+
+
+@dataclass(frozen=True)
+class TraceRSSStat:
+  pid: int
+  tgid: int
+  ts_ns: int
+  file: int
+  anon: int
+  swap: int
+  shmem: int
+
+class TraceRSSStatBPFHook(BPFProgram):
+
+  @classmethod
+  def name(cls) -> str:
+    return "mm_rss_stat"
+
+  def __init__(self):
+    self.is_support_raw_tp = True #  BPF.support_raw_tracepoint()
+    self.bpf_text = open(Path(__file__).parent / "bpf/mm_trace_rss_stat.bpf.c", "r").read()
+    self.trace_rss_stat = list[TraceRSSStat]()
+
+  def load(self, collection_id: str):
+    self.collection_id = collection_id
+    self.bpf = BPF(text = self.bpf_text)
+    #self.bpf.attach_raw_tracepoint(tp=b"mm_trace_rss_stat", fn_name=b"mm_trace_rss_stat")
+    self.bpf["rss_stat_output"].open_perf_buffer(self._mm_trace_rss_stat_eh, page_cnt=64)
+
+  def poll(self):
+    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+
+  def close(self):
+    self.bpf.cleanup()
+
+  def data(self) -> list[CollectionTable]:
+    return [
+            TraceMMRSSStatDataTable.from_df_id(
+                pl.DataFrame(self.trace_rss_stat),
+                collection_id=self.collection_id,
+            ),
+        ]
+
+  def clear(self):
+    self.trace_rss_stat.clear()
+
+  def pop_data(self) -> list[CollectionTable]:
+    quanta_tables = self.data()
+    self.clear()
+    return quanta_tables
+
+  def _mm_trace_rss_stat_eh(self, cpu, rss_stat_struct, size):
+      event = self.bpf["rss_stat_output"].event(rss_stat_struct)
+      self.trace_rss_stat.append(
+        TraceRSSStat(
+          pid=event.pid,
+          tgid=event.tgid,
+          ts_ns=event.ts,
+          file=event.file,
+          anon=event.anon,
+          swap=event.swap,
+          shmem=event.shmem,
+        )
+      )

--- a/python/kernmlops/data_schema/rss_stat.py
+++ b/python/kernmlops/data_schema/rss_stat.py
@@ -1,0 +1,38 @@
+import polars as pl
+from data_schema.schema import (
+    CollectionGraph,
+    CollectionTable,
+)
+
+
+class TraceMMRSSStatDataTable(CollectionTable):
+
+    @classmethod
+    def name(cls) -> str:
+        return "mm_rss_stat"
+
+    @classmethod
+    def schema(cls) -> pl.Schema:
+        return pl.Schema()
+
+    @classmethod
+    def from_df(cls, table: pl.DataFrame) -> "TraceMMRSSStatDataTable":
+        return TraceMMRSSStatDataTable(table=table)
+
+    def __init__(self, table: pl.DataFrame):
+        self._table = table
+
+    @property
+    def table(self) -> pl.DataFrame:
+        return self._table
+
+    def filtered_table(self) -> pl.DataFrame:
+        return self.table
+
+    def graphs(self) -> list[type[CollectionGraph]]:
+        return []
+
+    def by_pid(self, pids: int | list[int]) -> pl.DataFrame:
+        if isinstance(pids, int):
+            pids = [pids]
+        return self.filtered_table().filter(pl.col("pid").is_in(pids))


### PR DESCRIPTION
Enables data collection of Resident Set Size for all kernels with the tracepoint `rss_stat`.