### PR TITLE
Prevent redis from loading dump.rdb files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ This gives the most robust handling for multiple systems,
 see [here](https://github.com/iovisor/bcc/issues/2623#issuecomment-560214481).
 
 ### redis.clients.jedis.exceptions.JedisDataException
+<!-- TODO: move this section to a benchmark-specific doc --!>
 
 If you see the above error, you probably have stray `rdb` files that are causing
 `redis` to start slowly, and maybe influencing your runs in other unexpected

--- a/README.md
+++ b/README.md
@@ -303,3 +303,11 @@ quanta_runtimes.perf_submit(ctx, &data, sizeof(data));
 
 This gives the most robust handling for multiple systems,
 see [here](https://github.com/iovisor/bcc/issues/2623#issuecomment-560214481).
+
+### redis.clients.jedis.exceptions.JedisDataException
+
+If you see the above error, you probably have stray `rdb` files that are causing
+`redis` to start slowly, and maybe influencing your runs in other unexpected
+ways. Ensure that `load_from_rdb` is not set to true in the `redis` section of
+your benchmark config or always ensure that `dump.rdb` is not present before
+starting a collection!

--- a/config/start_overrides.yaml
+++ b/config/start_overrides.yaml
@@ -7,6 +7,7 @@ benchmark_config:
   redis:
     operation_count: 100
     record_count: 100
+    load_from_rdb: false
 collector_config:
   generic:
     poll_rate: 0.1

--- a/python/kernmlops/kernmlops_benchmark/redis.py
+++ b/python/kernmlops/kernmlops_benchmark/redis.py
@@ -2,6 +2,7 @@ import signal
 import subprocess
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import cast
 
 from data_schema import GraphEngine, demote
@@ -43,6 +44,8 @@ class RedisConfig(ConfigBase):
     sleep: str | None = None
     server_sleep: str | None = None
     explicit_purge: bool = False
+    load_from_rdb: bool = False
+
 
 
 size_redis = [
@@ -95,6 +98,11 @@ class RedisBenchmark(Benchmark):
             raise BenchmarkRunningError()
         if self.server is not None:
             raise BenchmarkRunningError()
+
+        if not self.config.load_from_rdb:
+            dump = Path("dump.rdb")
+            if dump.exists():
+                dump.unlink()
 
         # start the redis server
         start_redis = [

--- a/python/kernmlops/kernmlops_benchmark/redis.py
+++ b/python/kernmlops/kernmlops_benchmark/redis.py
@@ -1,3 +1,4 @@
+import shutil
 import signal
 import subprocess
 import time
@@ -102,7 +103,7 @@ class RedisBenchmark(Benchmark):
         if not self.config.load_from_rdb:
             dump = Path("dump.rdb")
             if dump.exists():
-                dump.unlink()
+                shutil.move(dump, dump.with_suffix(".rdb.bak"))
 
         # start the redis server
         start_redis = [

--- a/python/kernmlops/kernmlops_benchmark/redis.py
+++ b/python/kernmlops/kernmlops_benchmark/redis.py
@@ -48,7 +48,6 @@ class RedisConfig(ConfigBase):
     load_from_rdb: bool = False
 
 
-
 size_redis = [
     "redis-cli",
     "DBSIZE",


### PR DESCRIPTION
on startup, redis will load any `dump.rdb` files in the current directory to restore state. This may lead to unexpected outcomes for benchmarking, and in some cases, lead to timeouts since the client does not wait for redis to complete loading the data.